### PR TITLE
(Feat/5): Melhorar LeadingBrands.vue

### DIFF
--- a/src/components/Swiper.vue
+++ b/src/components/Swiper.vue
@@ -7,6 +7,7 @@
     :navigation="navigation"
     :freeMode="true"
     autoplay
+    :breakpoints="getBreakPoints"
   >
     <swiper-slide v-for="(item, index) in (slidesPerView * 2)" :key="index">
       <slot />
@@ -26,6 +27,7 @@ import 'swiper/css/navigation'
 import 'swiper/css/pagination'
 import 'swiper/css/scrollbar'
 import 'swiper/css/autoplay'
+import { computed } from 'vue'
 
 
 export default {
@@ -44,12 +46,34 @@ export default {
     }
   },
   setup() {
+
+    const getBreakPoints = computed( () => ({      
+    // Responsive breakpoints
+    
+      // when window width is >= 320px
+      320: {
+        slidesPerView: 2,
+        spaceBetween: 20
+      },
+      // when window width is >= 480px
+      480: {
+        slidesPerView: 3,
+        spaceBetween: 30
+      },
+      // when window width is >= 640px
+      640: {
+        slidesPerView: 5,
+        spaceBetween: 40
+      }
+    }));
+
     const onSlideChange = () => {
       console.log('slide change')
     }
     return {
       modules: [Navigation, Autoplay],
-      onSlideChange
+      onSlideChange,
+      getBreakPoints,
     }
   }
 }

--- a/src/components/Swiper.vue
+++ b/src/components/Swiper.vue
@@ -1,7 +1,6 @@
 <template>
   <swiper
-    :modules="modules"
-    :slides-per-view="slidesPerView"
+    :modules="modules"    
     :space-between="30"
     @slideChange="onSlideChange"
     :navigation="navigation"
@@ -45,24 +44,23 @@ export default {
       default: false
     }
   },
-  setup() {
+  setup(props) {
 
     const getBreakPoints = computed( () => ({      
     // Responsive breakpoints
     
       // when window width is >= 320px
       320: {
-        slidesPerView: 2,
+        slidesPerView: props.slidesPerView - 2,
         spaceBetween: 20
-      },
-      // when window width is >= 480px
-      480: {
-        slidesPerView: 3,
-        spaceBetween: 30
-      },
+      },      
       // when window width is >= 640px
       640: {
-        slidesPerView: 5,
+        slidesPerView: props.slidesPerView - 1,  
+        spaceBetween: 40
+      },
+      768: {
+        slidesPerView: props.slidesPerView,  
         spaceBetween: 40
       }
     }));

--- a/src/layout/section/LeadingBrands.vue
+++ b/src/layout/section/LeadingBrands.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="max-w-5xl my-96 sm:my-40 md:my-10   mx-[auto] pt-3 px-4" >
+    <section class="max-w-5xl my-14 sm:my-28 md:my-36   mx-[auto] pt-3 px-4" >
         <h1 class="text-center font-bold mb-14 md:text-3xl text-xl">Vivamus porttitor sem et odio tempor.</h1>
         <c-swiper>
           <img class="bg-emerald-50" width="170" height="130">

--- a/src/layout/section/LeadingBrands.vue
+++ b/src/layout/section/LeadingBrands.vue
@@ -1,6 +1,6 @@
 <template>
-    <section class="max-w-5xl mt-10 mb-40 mx-[auto] pt-3" >
-        <h1 class="text-center font-bold mb-14 text-3xl">Vivamus porttitor sem et odio tempor.</h1>
+    <section class="max-w-5xl my-96 sm:my-40 md:my-10   mx-[auto] pt-3 px-4" >
+        <h1 class="text-center font-bold mb-14 md:text-3xl text-xl">Vivamus porttitor sem et odio tempor.</h1>
         <c-swiper>
           <img class="bg-emerald-50" width="170" height="130">
         </c-swiper>


### PR DESCRIPTION
- Foi adicionado responsividade no componente LeadingBrands.vue.
```
<section class="max-w-5xl my-14 sm:my-28 md:my-36   mx-[auto] pt-3 px-4" >
        <h1 class="text-center font-bold mb-14 md:text-3xl text-xl">Vivamus porttitor sem et odio tempor.</h1>

```

- Adicionado a função getBreakPoints na diretiva :breakpoints para a responsividade do swiper
```
const getBreakPoints = computed( () => ({      
    // Responsive breakpoints
    
      // when window width is >= 320px
      320: {
        slidesPerView: props.slidesPerView - 2,
        spaceBetween: 20
      },      
      // when window width is >= 640px
      640: {
        slidesPerView: props.slidesPerView - 1,  
        spaceBetween: 40
      },
      768: {
        slidesPerView: props.slidesPerView,  
        spaceBetween: 40
      }
    }));
```


